### PR TITLE
Fix to image's number of pixels calculation

### DIFF
--- a/Application/src/main/java/com/example/android/displayingbitmaps/util/ImageResizer.java
+++ b/Application/src/main/java/com/example/android/displayingbitmaps/util/ImageResizer.java
@@ -254,14 +254,14 @@ public class ImageResizer extends ImageWorker {
             // end up being too large to fit comfortably in memory, so we should
             // be more aggressive with sample down the image (=larger inSampleSize).
 
-            long totalPixels = width * height / inSampleSize;
+            long totalPixels = width * height / (long) Math.pow(inSampleSize, 2);
 
             // Anything more than 2x the requested pixels we'll sample down further
             final long totalReqPixelsCap = reqWidth * reqHeight * 2;
 
             while (totalPixels > totalReqPixelsCap) {
                 inSampleSize *= 2;
-                totalPixels /= 2;
+                totalPixels = width * height / (long) Math.pow(inSampleSize, 2);
             }
         }
         return inSampleSize;


### PR DESCRIPTION
According to [BitmapFactory.Options.inSampleSize documentation](https://developer.android.com/reference/android/graphics/BitmapFactory.Options.html#inSampleSize)
> The sample size is the number of pixels in either dimension that correspond to a single pixel in the decoded bitmap. For example, inSampleSize == 4 returns an image that is 1/4 the width/height of the original, and 1/16 the number of pixels.

So the number of pixels can be obtained by dividing the original number of pixels by the 2nd power of the inSampleSize, instead of just by the inSampleSize: this made some sampled images look pixelated because inSampleSize became way much larger than needed.

The step to reproduce the bug is by trying to put very large images (eg. panoramic ones) into much smaller square thumbnails.