### PR TITLE
Update minSdkVersion to 14

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -38,7 +38,7 @@ android {
     buildToolsVersion "27.0.2"
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 22
     }
 


### PR DESCRIPTION
The min SDK version needs to be updated to 14, otherwise build will fail:
"Manifest merger failed : uses-sdk:minSdkVersion 9 cannot be smaller than version 14 declared in library [com.android.support:support-v4:27.0.2]"